### PR TITLE
프로필 사진 5번 터치로 Toolbox/Archive 진입 숨김 처리

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,5 +1,4 @@
-import { Link } from "react-router-dom";
-import { Github, Mail, LayoutGrid } from "lucide-react";
+import { Github, Mail } from "lucide-react";
 
 export default function Footer() {
   const year = new Date().getFullYear();
@@ -26,14 +25,6 @@ export default function Footer() {
           >
             <Mail size={18} />
           </a>
-          <Link
-            to="/tools"
-            className="btn btn-ghost gap-1.5 px-3 py-1.5 text-xs"
-            aria-label="Toolbox 열기"
-          >
-            <LayoutGrid size={14} />
-            Toolbox
-          </Link>
         </div>
       </div>
     </footer>

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { Link, useLocation, useNavigate } from "react-router-dom";
-import { BookOpen, Library, Menu, X } from "lucide-react";
+import { BookOpen, Menu, X } from "lucide-react";
 import { cn } from "../lib/cn";
 
 const SECTIONS = [
@@ -71,16 +71,6 @@ export default function Navbar() {
             <BookOpen size={16} />
             Blog
           </Link>
-          <Link
-            to="/archive"
-            className={cn(
-              "btn px-3.5 py-2 text-sm",
-              location.pathname.startsWith("/archive") ? "btn-primary" : "btn-ghost"
-            )}
-          >
-            <Library size={16} />
-            Archive
-          </Link>
         </div>
 
         <button
@@ -111,14 +101,6 @@ export default function Navbar() {
           >
             <BookOpen size={16} />
             Blog
-          </Link>
-          <Link
-            to="/archive"
-            onClick={() => setOpen(false)}
-            className="btn btn-ghost mt-1 w-full"
-          >
-            <Library size={16} />
-            Archive
           </Link>
         </div>
       )}

--- a/src/sections/About.tsx
+++ b/src/sections/About.tsx
@@ -1,8 +1,24 @@
-import { Lightbulb, Feather, Rocket, MonitorSmartphone, Briefcase } from "lucide-react";
+import { useRef, useState } from "react";
+import { Link } from "react-router-dom";
+import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
+import {
+  Lightbulb,
+  Feather,
+  Rocket,
+  MonitorSmartphone,
+  Briefcase,
+  LayoutGrid,
+  Library,
+} from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 import profileImage from "../assets/images/profileImage.jpg";
 import SectionHeader from "../components/SectionHeader";
 import Reveal from "../components/Reveal";
+
+// Tapping the profile photo this many times in quick succession reveals the
+// hidden navigation to the Toolbox & Archive pages (kept off the main UI).
+const SECRET_TAPS = 5;
+const TAP_RESET_MS = 1200;
 
 type Value = { title: string; icon: LucideIcon; desc: string };
 
@@ -14,6 +30,25 @@ const VALUES: Value[] = [
 ];
 
 export default function About() {
+  const reduceMotion = useReducedMotion();
+  const [secretOpen, setSecretOpen] = useState(false);
+  const tapsRef = useRef(0);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+
+  const handleProfileTap = () => {
+    if (secretOpen) return;
+    tapsRef.current += 1;
+    if (timerRef.current) clearTimeout(timerRef.current);
+    if (tapsRef.current >= SECRET_TAPS) {
+      tapsRef.current = 0;
+      setSecretOpen(true);
+      return;
+    }
+    timerRef.current = setTimeout(() => {
+      tapsRef.current = 0;
+    }, TAP_RESET_MS);
+  };
+
   return (
     <section className="section">
       <div className="container-x">
@@ -31,15 +66,46 @@ export default function About() {
           {/* Profile card */}
           <Reveal className="md:col-span-1 md:row-span-2">
             <article className="bento flex h-full flex-col p-6">
-              <div className="relative mx-auto aspect-square w-40 overflow-hidden rounded-2xl ring-1 ring-white/10 md:w-full">
+              <button
+                type="button"
+                onClick={handleProfileTap}
+                aria-label="정훈 프로필"
+                className="group relative mx-auto block aspect-square w-40 cursor-pointer select-none overflow-hidden rounded-2xl ring-1 ring-white/10 md:w-full"
+              >
                 <img
                   src={profileImage}
                   alt="정훈 프로필"
                   className="h-full w-full object-cover"
                   loading="lazy"
+                  draggable={false}
                 />
                 <div className="absolute inset-0 bg-gradient-to-t from-bg/70 to-transparent" />
-              </div>
+              </button>
+
+              {/* Hidden navigation — revealed by tapping the photo 5 times */}
+              <AnimatePresence initial={false}>
+                {secretOpen && (
+                  <motion.div
+                    key="secret-nav"
+                    initial={reduceMotion ? false : { opacity: 0, height: 0 }}
+                    animate={{ opacity: 1, height: "auto" }}
+                    exit={reduceMotion ? undefined : { opacity: 0, height: 0 }}
+                    transition={{ duration: 0.4, ease: [0.22, 1, 0.36, 1] }}
+                    className="overflow-hidden"
+                  >
+                    <div className="mt-4 flex flex-col gap-2">
+                      <Link to="/tools" className="btn btn-ghost w-full justify-start">
+                        <LayoutGrid size={16} className="text-accent" />
+                        Toolbox
+                      </Link>
+                      <Link to="/archive" className="btn btn-ghost w-full justify-start">
+                        <Library size={16} className="text-brand" />
+                        Archive
+                      </Link>
+                    </div>
+                  </motion.div>
+                )}
+              </AnimatePresence>
               <div className="mt-5">
                 <h3 className="text-2xl font-bold">
                   SW 개발자 <span className="text-gradient">정훈</span>

--- a/src/sections/Contact.tsx
+++ b/src/sections/Contact.tsx
@@ -1,6 +1,5 @@
 import { useState } from "react";
-import { Link } from "react-router-dom";
-import { Check, Copy, Github, Mail, Code2, ArrowUpRight, LayoutGrid } from "lucide-react";
+import { Check, Copy, Github, Mail, Code2, ArrowUpRight } from "lucide-react";
 import SectionHeader from "../components/SectionHeader";
 import Reveal from "../components/Reveal";
 
@@ -89,24 +88,6 @@ export default function Contact() {
               </div>
               <ArrowUpRight size={18} className="text-muted transition-transform group-hover:translate-x-0.5 group-hover:-translate-y-0.5" />
             </a>
-          </Reveal>
-
-          <Reveal delay={0.15} className="sm:col-span-2">
-            <Link
-              to="/tools"
-              className="bento group flex items-center justify-between p-6"
-            >
-              <div className="flex items-center gap-4">
-                <span className="grid h-12 w-12 place-items-center rounded-xl bg-gradient-to-br from-accent/30 to-brand/20 ring-1 ring-white/10">
-                  <LayoutGrid size={22} className="text-accent" />
-                </span>
-                <div>
-                  <p className="text-xs text-muted">개인 도구함</p>
-                  <p className="font-semibold">보드게임 타이머 · 카운터 · 유틸리티 모음</p>
-                </div>
-              </div>
-              <ArrowUpRight size={18} className="text-muted transition-transform group-hover:translate-x-0.5 group-hover:-translate-y-0.5" />
-            </Link>
           </Reveal>
         </div>
       </div>


### PR DESCRIPTION
## 변경 내용

홈 화면에 노출돼 있던 Toolbox / Archive 진입 버튼을 숨기고, **About 섹션의 프로필 사진을 5번 연속 터치**하면 사진 아래에 두 페이지로의 이동 버튼이 나타나도록 변경했습니다.

### 세부 사항
- **About.tsx** — 프로필 사진을 `button`으로 감싸 탭 카운트(연속 5회, 1.2초 내). 5회 도달 시 사진 아래로 `Toolbox`(`/tools`) · `Archive`(`/archive`) 버튼을 애니메이션과 함께 노출. `prefers-reduced-motion` 존중.
- **Navbar.tsx** — 데스크탑·모바일의 Archive 버튼 제거 (Blog는 유지).
- **Footer.tsx** — Toolbox 버튼 제거.
- **Contact.tsx** — 도구함 안내 카드 제거.
- **Archive 업로드 버튼** — 기존대로 소유자(`gnslalsl12`)만 노출되며 변경 없음.

### 검증
- `npm run typecheck` 통과
- `npm run build` 통과

https://claude.ai/code/session_01EUD9jCZ3HGeL7y4CAjwLap

---
_Generated by [Claude Code](https://claude.ai/code/session_01EUD9jCZ3HGeL7y4CAjwLap)_