### PR TITLE
fix(archive): 모바일(터치)에서도 삭제 버튼 노출

### DIFF
--- a/src/pages/Archive.tsx
+++ b/src/pages/Archive.tsx
@@ -224,7 +224,7 @@ export default function Archive() {
                           disabled={deletingPath === doc.path}
                           aria-label="문서 삭제"
                           title="문서 삭제"
-                          className="absolute bottom-3 right-3 grid h-8 w-8 place-items-center rounded-lg border border-white/10 bg-white/5 text-muted opacity-0 transition-all hover:border-red-500/40 hover:bg-red-500/10 hover:text-red-300 focus-visible:opacity-100 group-hover:opacity-100 disabled:opacity-100"
+                          className="absolute bottom-3 right-3 grid h-8 w-8 place-items-center rounded-lg border border-white/10 bg-white/5 text-muted opacity-0 transition-all hover:border-red-500/40 hover:bg-red-500/10 hover:text-red-300 focus-visible:opacity-100 group-hover:opacity-100 disabled:opacity-100 [@media(hover:none)]:opacity-100"
                         >
                           {deletingPath === doc.path ? (
                             <Loader2 size={15} className="animate-spin" />


### PR DESCRIPTION
## 배경
소유자 전용 삭제 버튼이 `group-hover`로만 나타나 **터치 기기(모바일)에서는 노출되지 않는** 문제가 있었습니다(hover 이벤트 없음).

## 변경
- 버튼에 `[@media(hover:none)]:opacity-100` 변형 추가 → hover 불가 기기(터치)에서는 항상 표시, 포인터 기기에서는 기존 hover-reveal 유지.

## 검증
- `npm run typecheck` ✅ · `npm run build` ✅ (`@media (hover: none)` 규칙이 CSS에 생성됨 확인)

> 참고: 표시 여부와 별개로 실제 삭제 권한은 여전히 소유자 토큰 검증(`canUpload`)으로 게이트됩니다.

https://claude.ai/code/session_0131VNZxJHuHREuhS6SqTEoo

---
_Generated by [Claude Code](https://claude.ai/code/session_0131VNZxJHuHREuhS6SqTEoo)_