### PR TITLE
feat: 포트폴리오 강화 6종 (진행바·도트내비·타임라인·GitHub 잔디·방명록·2048)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,10 +8,15 @@
 - **성격**: 백엔드 없는 **정적 SPA**. GitHub Pages **사용자 페이지**(`gnslalsl12.github.io`)로
   루트 도메인에 배포되므로 Vite `base`는 `/`.
 - **라우트**
-  - `/` — 포트폴리오 (Hero · About · Skills · Projects · Contact)
+  - `/` — 포트폴리오 (Hero · About · Journey(타임라인) · Skills · Projects · Contact).
+    전역 스크롤 진행바(`ScrollProgress`)·우측 섹션 도트 내비(`SectionDots`, 데스크톱) 포함.
   - `/tools` — 도구함 14종 (전부 브라우저 로컬 저장, 설치 불필요)
   - `/blog` · `/blog/:number` · `/blog/write` — 블로그 (목록 / 상세 / 작성·게시, GitHub Issues 기반)
   - `/archive` · `/archive/upload` — 문서 아카이브 (standalone HTML 문서 허브 / 업로드)
+  - `/guestbook` — 방명록 (giscus = GitHub Discussions 기반. `src/pages/Guestbook.tsx`의
+    `GISCUS.repoId`/`categoryId`를 채우기 전엔 설정 안내가 표시됨)
+  - `/2048` — 숨겨진 2048 미니게임 이스터에그 (키보드·WASD·모바일 스와이프, 최고점 localStorage).
+    About 프로필 5탭 시크릿 내비로 진입 가능.
 
 ## 기술 스택
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from "react";
 import { Routes, Route, useLocation } from "react-router-dom";
 import Backdrop from "./components/Backdrop";
+import ScrollProgress from "./components/ScrollProgress";
 import Navbar from "./components/Navbar";
 import Footer from "./components/Footer";
 import Portfolio from "./pages/Portfolio";
@@ -10,6 +11,8 @@ import BlogPost from "./pages/BlogPost";
 import BlogWrite from "./pages/BlogWrite";
 import Archive from "./pages/Archive";
 import ArchiveUpload from "./pages/ArchiveUpload";
+import Guestbook from "./pages/Guestbook";
+import Game2048 from "./pages/Game2048";
 
 export default function App() {
   const location = useLocation();
@@ -22,6 +25,7 @@ export default function App() {
   return (
     <>
       <Backdrop />
+      <ScrollProgress />
       <Navbar />
       <main>
         <Routes>
@@ -32,6 +36,8 @@ export default function App() {
           <Route path="/blog/:number" element={<BlogPost />} />
           <Route path="/archive" element={<Archive />} />
           <Route path="/archive/upload" element={<ArchiveUpload />} />
+          <Route path="/guestbook" element={<Guestbook />} />
+          <Route path="/2048" element={<Game2048 />} />
           <Route path="*" element={<Portfolio />} />
         </Routes>
       </main>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,4 +1,5 @@
-import { Github, Mail } from "lucide-react";
+import { Link } from "react-router-dom";
+import { Github, Mail, MessageSquareHeart } from "lucide-react";
 
 export default function Footer() {
   const year = new Date().getFullYear();
@@ -9,6 +10,14 @@ export default function Footer() {
           © {year} Jeong Hoon. Built with React · Vite · Tailwind.
         </p>
         <div className="flex items-center gap-4 text-muted">
+          <Link
+            to="/guestbook"
+            className="inline-flex items-center gap-1.5 text-sm transition-colors hover:text-text"
+          >
+            <MessageSquareHeart size={16} />
+            방명록
+          </Link>
+          <span className="h-3 w-px bg-white/10" aria-hidden="true" />
           <a
             href="https://github.com/gnslalsl12"
             target="_blank"

--- a/src/components/GithubActivity.tsx
+++ b/src/components/GithubActivity.tsx
@@ -4,26 +4,31 @@ import { REPO_OWNER } from "../lib/blog";
 
 // Public, tokenless contribution data. Returns the last year of daily counts
 // with a precomputed intensity level (0–4) we map straight onto color steps.
+// NOTE: this is an unofficial community proxy (no SLA) — if it goes down or
+// changes shape, the component falls back to a quiet error message. The
+// `ApiResponse` type is a trust assertion, not a validated schema.
 const API = `https://github-contributions-api.jogruber.de/v4/${REPO_OWNER}?y=last`;
 
 type Day = { date: string; count: number; level: 0 | 1 | 2 | 3 | 4 };
+type MaybeDay = Day | null; // null = padding cell to align the first week
 type ApiResponse = { total: Record<string, number>; contributions: Day[] };
 
-// Brand-tinted intensity ramp (level 0 = empty cell).
+// Brand-tinted intensity ramp (level 0 = empty cell). Derived from the
+// --color-brand token via color-mix so it tracks the design system.
 const LEVEL_BG = [
   "rgba(255,255,255,0.05)",
-  "rgba(139,92,246,0.28)",
-  "rgba(139,92,246,0.48)",
-  "rgba(139,92,246,0.72)",
-  "rgba(139,92,246,1)",
+  "color-mix(in srgb, var(--color-brand) 28%, transparent)",
+  "color-mix(in srgb, var(--color-brand) 48%, transparent)",
+  "color-mix(in srgb, var(--color-brand) 72%, transparent)",
+  "var(--color-brand)",
 ];
 
 /** Split a flat day list into week columns (each column = 7 days, Sun→Sat). */
-function toWeeks(days: Day[]): Day[][] {
-  const weeks: Day[][] = [];
+function toWeeks(days: Day[]): MaybeDay[][] {
+  const weeks: MaybeDay[][] = [];
   // Pad the first week so the grid aligns to the weekday of the first entry.
   const firstWeekday = days.length ? new Date(days[0].date).getDay() : 0;
-  let current: Day[] = new Array(firstWeekday).fill(null);
+  let current: MaybeDay[] = new Array<MaybeDay>(firstWeekday).fill(null);
   for (const d of days) {
     current.push(d);
     if (current.length === 7) {
@@ -32,7 +37,7 @@ function toWeeks(days: Day[]): Day[][] {
     }
   }
   if (current.length) {
-    while (current.length < 7) current.push(null as unknown as Day);
+    while (current.length < 7) current.push(null);
     weeks.push(current);
   }
   return weeks;
@@ -40,7 +45,7 @@ function toWeeks(days: Day[]): Day[][] {
 
 export default function GithubActivity() {
   const [status, setStatus] = useState<"loading" | "ready" | "error">("loading");
-  const [weeks, setWeeks] = useState<Day[][]>([]);
+  const [weeks, setWeeks] = useState<MaybeDay[][]>([]);
   const [total, setTotal] = useState(0);
 
   useEffect(() => {
@@ -100,7 +105,11 @@ export default function GithubActivity() {
           <p className="text-sm text-muted">잔디를 불러오지 못했어요. GitHub에서 직접 확인해 주세요.</p>
         )}
         {status === "ready" && (
-          <div className="overflow-x-auto pb-1">
+          <div
+            role="img"
+            aria-label={`지난 1년 GitHub 기여 히트맵 · 총 ${total.toLocaleString()} contributions`}
+            className="overflow-x-auto pb-1"
+          >
             <div className="flex gap-[3px]">
               {weeks.map((week, wi) => (
                 <div key={wi} className="flex flex-col gap-[3px]">

--- a/src/components/GithubActivity.tsx
+++ b/src/components/GithubActivity.tsx
@@ -1,0 +1,123 @@
+import { useEffect, useState } from "react";
+import { Github, Loader2 } from "lucide-react";
+import { REPO_OWNER } from "../lib/blog";
+
+// Public, tokenless contribution data. Returns the last year of daily counts
+// with a precomputed intensity level (0–4) we map straight onto color steps.
+const API = `https://github-contributions-api.jogruber.de/v4/${REPO_OWNER}?y=last`;
+
+type Day = { date: string; count: number; level: 0 | 1 | 2 | 3 | 4 };
+type ApiResponse = { total: Record<string, number>; contributions: Day[] };
+
+// Brand-tinted intensity ramp (level 0 = empty cell).
+const LEVEL_BG = [
+  "rgba(255,255,255,0.05)",
+  "rgba(139,92,246,0.28)",
+  "rgba(139,92,246,0.48)",
+  "rgba(139,92,246,0.72)",
+  "rgba(139,92,246,1)",
+];
+
+/** Split a flat day list into week columns (each column = 7 days, Sun→Sat). */
+function toWeeks(days: Day[]): Day[][] {
+  const weeks: Day[][] = [];
+  // Pad the first week so the grid aligns to the weekday of the first entry.
+  const firstWeekday = days.length ? new Date(days[0].date).getDay() : 0;
+  let current: Day[] = new Array(firstWeekday).fill(null);
+  for (const d of days) {
+    current.push(d);
+    if (current.length === 7) {
+      weeks.push(current);
+      current = [];
+    }
+  }
+  if (current.length) {
+    while (current.length < 7) current.push(null as unknown as Day);
+    weeks.push(current);
+  }
+  return weeks;
+}
+
+export default function GithubActivity() {
+  const [status, setStatus] = useState<"loading" | "ready" | "error">("loading");
+  const [weeks, setWeeks] = useState<Day[][]>([]);
+  const [total, setTotal] = useState(0);
+
+  useEffect(() => {
+    let alive = true;
+    fetch(API)
+      .then((r) => {
+        if (!r.ok) throw new Error(String(r.status));
+        return r.json() as Promise<ApiResponse>;
+      })
+      .then((data) => {
+        if (!alive) return;
+        const days = data.contributions ?? [];
+        setWeeks(toWeeks(days));
+        setTotal(days.reduce((sum, d) => sum + (d?.count ?? 0), 0));
+        setStatus("ready");
+      })
+      .catch(() => alive && setStatus("error"));
+    return () => {
+      alive = false;
+    };
+  }, []);
+
+  return (
+    <a
+      href={`https://github.com/${REPO_OWNER}`}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="bento group block p-6"
+    >
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-3">
+          <span className="grid h-10 w-10 place-items-center rounded-xl bg-white/5 ring-1 ring-white/10">
+            <Github size={20} className="text-brand" />
+          </span>
+          <div>
+            <p className="text-xs text-muted">GitHub 활동</p>
+            <p className="font-semibold transition-colors group-hover:text-brand">
+              지난 1년 잔디
+            </p>
+          </div>
+        </div>
+        {status === "ready" && (
+          <span className="text-sm text-muted">
+            <strong className="text-text">{total.toLocaleString()}</strong> contributions
+          </span>
+        )}
+      </div>
+
+      <div className="mt-5">
+        {status === "loading" && (
+          <div className="flex items-center gap-2 text-sm text-muted">
+            <Loader2 size={16} className="animate-spin" />
+            불러오는 중…
+          </div>
+        )}
+        {status === "error" && (
+          <p className="text-sm text-muted">잔디를 불러오지 못했어요. GitHub에서 직접 확인해 주세요.</p>
+        )}
+        {status === "ready" && (
+          <div className="overflow-x-auto pb-1">
+            <div className="flex gap-[3px]">
+              {weeks.map((week, wi) => (
+                <div key={wi} className="flex flex-col gap-[3px]">
+                  {week.map((day, di) => (
+                    <span
+                      key={di}
+                      title={day ? `${day.date} · ${day.count}` : undefined}
+                      className="h-[11px] w-[11px] rounded-[2px]"
+                      style={{ background: day ? LEVEL_BG[day.level] : "transparent" }}
+                    />
+                  ))}
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+    </a>
+  );
+}

--- a/src/components/ScrollProgress.tsx
+++ b/src/components/ScrollProgress.tsx
@@ -1,13 +1,18 @@
-import { motion, useScroll, useSpring } from "framer-motion";
+import { motion, useReducedMotion, useScroll, useSpring } from "framer-motion";
 
 /**
  * Thin gradient bar pinned to the very top of the viewport that fills as the
- * page scrolls. Driven by Framer's `useScroll` (scrollYProgress 0→1) and
- * smoothed with a spring. Purely decorative, so it stays out of the tab order.
+ * page scrolls. Driven by Framer's `useScroll` (scrollYProgress 0→1).
+ *
+ * Note: `useSpring` is a JS motion value, so `MotionConfig reducedMotion` and
+ * the CSS reduced-motion rules don't touch it — we explicitly bind the raw
+ * (instant) progress when the user prefers reduced motion. Purely decorative,
+ * so it stays out of the tab order.
  */
 export default function ScrollProgress() {
+  const reduced = useReducedMotion();
   const { scrollYProgress } = useScroll();
-  const scaleX = useSpring(scrollYProgress, {
+  const smooth = useSpring(scrollYProgress, {
     stiffness: 120,
     damping: 30,
     restDelta: 0.001,
@@ -16,7 +21,7 @@ export default function ScrollProgress() {
   return (
     <motion.div
       aria-hidden="true"
-      style={{ scaleX }}
+      style={{ scaleX: reduced ? scrollYProgress : smooth }}
       className="fixed inset-x-0 top-0 z-[60] h-0.5 origin-left bg-gradient-to-r from-brand via-brand-3 to-accent"
     />
   );

--- a/src/components/ScrollProgress.tsx
+++ b/src/components/ScrollProgress.tsx
@@ -1,0 +1,23 @@
+import { motion, useScroll, useSpring } from "framer-motion";
+
+/**
+ * Thin gradient bar pinned to the very top of the viewport that fills as the
+ * page scrolls. Driven by Framer's `useScroll` (scrollYProgress 0→1) and
+ * smoothed with a spring. Purely decorative, so it stays out of the tab order.
+ */
+export default function ScrollProgress() {
+  const { scrollYProgress } = useScroll();
+  const scaleX = useSpring(scrollYProgress, {
+    stiffness: 120,
+    damping: 30,
+    restDelta: 0.001,
+  });
+
+  return (
+    <motion.div
+      aria-hidden="true"
+      style={{ scaleX }}
+      className="fixed inset-x-0 top-0 z-[60] h-0.5 origin-left bg-gradient-to-r from-brand via-brand-3 to-accent"
+    />
+  );
+}

--- a/src/components/SectionDots.tsx
+++ b/src/components/SectionDots.tsx
@@ -42,7 +42,10 @@ export default function SectionDots() {
   }, []);
 
   const jump = (id: string) => {
-    document.getElementById(id)?.scrollIntoView({ behavior: "smooth" });
+    const reduced = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+    document.getElementById(id)?.scrollIntoView({
+      behavior: reduced ? "auto" : "smooth",
+    });
   };
 
   return (
@@ -68,7 +71,7 @@ export default function SectionDots() {
                   : "h-2 w-2 bg-white/25 group-hover:bg-white/60")
               }
             />
-            <span className="pointer-events-none absolute right-6 whitespace-nowrap rounded-md bg-surface/90 px-2 py-1 text-xs text-muted opacity-0 ring-1 ring-white/10 transition-opacity duration-200 group-hover:opacity-100">
+            <span className="pointer-events-none absolute right-full mr-3 whitespace-nowrap rounded-md bg-surface/90 px-2 py-1 text-xs text-muted opacity-0 ring-1 ring-white/10 transition-opacity duration-200 group-hover:opacity-100">
               {s.label}
             </span>
           </button>

--- a/src/components/SectionDots.tsx
+++ b/src/components/SectionDots.tsx
@@ -1,0 +1,79 @@
+import { useEffect, useState } from "react";
+
+type Section = { id: string; label: string };
+
+// Order matches the portfolio sections (Hero has id="hero").
+const SECTIONS: Section[] = [
+  { id: "hero", label: "Home" },
+  { id: "about", label: "About" },
+  { id: "journey", label: "Journey" },
+  { id: "skills", label: "Skills" },
+  { id: "projects", label: "Projects" },
+  { id: "contact", label: "Contact" },
+];
+
+/**
+ * Fixed vertical dot navigation down the right edge (desktop only). Tracks the
+ * section currently in view with an IntersectionObserver and lets the user jump
+ * between sections. Hidden on small screens where it would crowd the content.
+ */
+export default function SectionDots() {
+  const [active, setActive] = useState<string>(SECTIONS[0].id);
+
+  useEffect(() => {
+    const els = SECTIONS.map((s) => document.getElementById(s.id)).filter(
+      (el): el is HTMLElement => el !== null
+    );
+    if (!els.length) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        // Pick the most-visible intersecting section.
+        const visible = entries
+          .filter((e) => e.isIntersecting)
+          .sort((a, b) => b.intersectionRatio - a.intersectionRatio)[0];
+        if (visible) setActive(visible.target.id);
+      },
+      { rootMargin: "-45% 0px -45% 0px", threshold: [0, 0.25, 0.5, 1] }
+    );
+
+    els.forEach((el) => observer.observe(el));
+    return () => observer.disconnect();
+  }, []);
+
+  const jump = (id: string) => {
+    document.getElementById(id)?.scrollIntoView({ behavior: "smooth" });
+  };
+
+  return (
+    <nav
+      aria-label="섹션 이동"
+      className="fixed right-6 top-1/2 z-40 hidden -translate-y-1/2 flex-col items-center gap-4 lg:flex"
+    >
+      {SECTIONS.map((s) => {
+        const isActive = active === s.id;
+        return (
+          <button
+            key={s.id}
+            onClick={() => jump(s.id)}
+            aria-label={s.label}
+            aria-current={isActive ? "true" : undefined}
+            className="group relative grid place-items-center"
+          >
+            <span
+              className={
+                "block rounded-full transition-all duration-300 " +
+                (isActive
+                  ? "h-2.5 w-2.5 bg-brand shadow-[0_0_10px_2px_var(--glow-brand)]"
+                  : "h-2 w-2 bg-white/25 group-hover:bg-white/60")
+              }
+            />
+            <span className="pointer-events-none absolute right-6 whitespace-nowrap rounded-md bg-surface/90 px-2 py-1 text-xs text-muted opacity-0 ring-1 ring-white/10 transition-opacity duration-200 group-hover:opacity-100">
+              {s.label}
+            </span>
+          </button>
+        );
+      })}
+    </nav>
+  );
+}

--- a/src/data/timeline.ts
+++ b/src/data/timeline.ts
@@ -1,0 +1,71 @@
+// Career / education / project timeline shown on the portfolio. Ordered most
+// recent first. Edit freely — dates and copy are plain data.
+
+export type TimelineKind = "work" | "education" | "award" | "project";
+
+export type TimelineEntry = {
+  period: string; // free-form, e.g. "2024.05 ~ 현재"
+  title: string;
+  org?: string;
+  kind: TimelineKind;
+  description?: string;
+  tags?: string[];
+};
+
+export const timeline: TimelineEntry[] = [
+  {
+    period: "2024.05 ~ 현재",
+    title: "하나금융티아이 · AI솔루션셀",
+    org: "재직 중",
+    kind: "work",
+    description: "AI 솔루션 개발·운영. 사용자 관점에서 문제를 정의하고 완성도 높은 결과물을 만듭니다.",
+    tags: ["Frontend", "AI Solution"],
+  },
+  {
+    period: "진행 중",
+    title: "Famring",
+    org: "개인 프로젝트 · 운영 중",
+    kind: "project",
+    description: "가족 단위로 계정·일정·정보를 안전하게 공유하는 모바일 PWA를 1인 풀스택으로 기획·개발·운영.",
+    tags: ["PWA", "풀스택", "보안 설계"],
+  },
+  {
+    period: "2023.06",
+    title: "SSAFY 8기 수료",
+    org: "삼성 청년 SW 아카데미",
+    kind: "education",
+    description: "1년간 알고리즘·웹·프로젝트 중심의 집중 교육 과정 이수.",
+    tags: ["Frontend", "Algorithm"],
+  },
+  {
+    period: "2023.04 ~ 05",
+    title: "WORLDY — SSAFY 자율 PJT",
+    org: "프론트엔드 리더 · 우수상",
+    kind: "award",
+    description: "AI 기술을 활용한 3D 메타버스 세계 지식 학습 게임. 자율 프로젝트 우수상 수상.",
+    tags: ["React", "Three.js", "리더"],
+  },
+  {
+    period: "2023.02 ~ 04",
+    title: "이음",
+    org: "특화 프로젝트",
+    kind: "project",
+    description: "빅데이터 분산 기술을 활용한 '자립 준비 청년' 사회적 지원 서비스.",
+    tags: ["React", "Big Data"],
+  },
+  {
+    period: "2023.01 ~ 02",
+    title: "Rendez-Boo",
+    org: "공통 프로젝트",
+    kind: "project",
+    description: "WebRTC 기술을 활용한 블라인드 미팅 플랫폼.",
+    tags: ["React", "WebRTC"],
+  },
+  {
+    period: "2022.07",
+    title: "SSAFY 8기 시작",
+    org: "삼성 청년 SW 아카데미",
+    kind: "education",
+    description: "SW 개발자로서의 여정을 본격적으로 시작.",
+  },
+];

--- a/src/index.css
+++ b/src/index.css
@@ -334,6 +334,12 @@
   from { transform: translateX(0); }
   to { transform: translateX(-50%); }
 }
+/* Tile spawn/merge pop — used by the 2048 easter-egg game. */
+@keyframes pop {
+  0% { transform: scale(0.85); }
+  60% { transform: scale(1.04); }
+  100% { transform: scale(1); }
+}
 
 .animate-float { animation: float 6s ease-in-out infinite; }
 .animate-spin-slow { animation: spin-slow 14s linear infinite; }

--- a/src/pages/Game2048.tsx
+++ b/src/pages/Game2048.tsx
@@ -1,0 +1,289 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Link } from "react-router-dom";
+import { ArrowLeft, RotateCcw, Trophy } from "lucide-react";
+import { useLocalStorage } from "../lib/useLocalStorage";
+
+// ── 2048 ────────────────────────────────────────────────────────────────
+// A hidden easter-egg game. Classic rules: slide tiles, equal ones merge,
+// reach 2048. Works with arrow keys / WASD on desktop and swipes on touch.
+
+type Board = number[][]; // 4×4, 0 = empty
+const SIZE = 4;
+
+const empty = (): Board =>
+  Array.from({ length: SIZE }, () => Array<number>(SIZE).fill(0));
+
+function clone(b: Board): Board {
+  return b.map((row) => [...row]);
+}
+
+function emptyCells(b: Board): [number, number][] {
+  const cells: [number, number][] = [];
+  for (let r = 0; r < SIZE; r++)
+    for (let c = 0; c < SIZE; c++) if (b[r][c] === 0) cells.push([r, c]);
+  return cells;
+}
+
+function spawn(b: Board): Board {
+  const cells = emptyCells(b);
+  if (!cells.length) return b;
+  const [r, c] = cells[Math.floor(Math.random() * cells.length)];
+  const next = clone(b);
+  next[r][c] = Math.random() < 0.9 ? 2 : 4;
+  return next;
+}
+
+/** Slide + merge a single row to the left. Returns the row and points gained. */
+function slideRow(row: number[]): { row: number[]; gained: number } {
+  const nums = row.filter((n) => n !== 0);
+  const merged: number[] = [];
+  let gained = 0;
+  for (let i = 0; i < nums.length; i++) {
+    if (i + 1 < nums.length && nums[i] === nums[i + 1]) {
+      const sum = nums[i] * 2;
+      merged.push(sum);
+      gained += sum;
+      i++; // skip the consumed tile
+    } else {
+      merged.push(nums[i]);
+    }
+  }
+  while (merged.length < SIZE) merged.push(0);
+  return { row: merged, gained };
+}
+
+type Dir = "left" | "right" | "up" | "down";
+
+function move(b: Board, dir: Dir): { board: Board; gained: number; moved: boolean } {
+  // Normalize every direction to a left-slide by transforming the grid.
+  const rows: number[][] = [];
+  for (let i = 0; i < SIZE; i++) {
+    let line: number[];
+    if (dir === "left" || dir === "right") {
+      line = [...b[i]];
+      if (dir === "right") line.reverse();
+    } else {
+      line = b.map((row) => row[i]); // column
+      if (dir === "down") line.reverse();
+    }
+    rows.push(line);
+  }
+
+  let gained = 0;
+  const slid = rows.map((line) => {
+    const res = slideRow(line);
+    gained += res.gained;
+    return res.row;
+  });
+
+  const next = empty();
+  for (let i = 0; i < SIZE; i++) {
+    let line = slid[i];
+    if (dir === "right" || dir === "down") line = [...line].reverse();
+    for (let j = 0; j < SIZE; j++) {
+      if (dir === "left" || dir === "right") next[i][j] = line[j];
+      else next[j][i] = line[j];
+    }
+  }
+
+  const moved = JSON.stringify(next) !== JSON.stringify(b);
+  return { board: next, gained, moved };
+}
+
+function canMove(b: Board): boolean {
+  if (emptyCells(b).length) return true;
+  for (let r = 0; r < SIZE; r++)
+    for (let c = 0; c < SIZE; c++) {
+      if (c + 1 < SIZE && b[r][c] === b[r][c + 1]) return true;
+      if (r + 1 < SIZE && b[r][c] === b[r + 1][c]) return true;
+    }
+  return false;
+}
+
+function freshBoard(): Board {
+  return spawn(spawn(empty()));
+}
+
+// Tile color ramp — brand-tinted, brightening with value.
+const TILE: Record<number, string> = {
+  0: "bg-white/5 text-transparent",
+  2: "bg-white/10 text-text",
+  4: "bg-white/[0.16] text-text",
+  8: "bg-brand/30 text-text",
+  16: "bg-brand/45 text-white",
+  32: "bg-brand/60 text-white",
+  64: "bg-brand/80 text-white",
+  128: "bg-brand text-white",
+  256: "bg-accent/70 text-white",
+  512: "bg-accent/85 text-white",
+  1024: "bg-accent text-white",
+  2048: "bg-gradient-to-br from-brand to-accent text-white",
+};
+
+const SWIPE_THRESHOLD = 24; // px
+
+export default function Game2048() {
+  const [board, setBoard] = useState<Board>(freshBoard);
+  const [score, setScore] = useState(0);
+  const [best, setBest] = useLocalStorage<number>("game:2048:best", 0);
+  const [over, setOver] = useState(false);
+  const [won, setWon] = useState(false);
+  const touchStart = useRef<{ x: number; y: number } | null>(null);
+
+  const apply = useCallback(
+    (dir: Dir) => {
+      setBoard((prev) => {
+        if (!canMove(prev)) return prev;
+        const { board: next, gained, moved } = move(prev, dir);
+        if (!moved) return prev;
+        const withSpawn = spawn(next);
+        setScore((s) => {
+          const ns = s + gained;
+          setBest((b) => (ns > b ? ns : b));
+          return ns;
+        });
+        if (!won && withSpawn.some((row) => row.includes(2048))) setWon(true);
+        if (!canMove(withSpawn)) setOver(true);
+        return withSpawn;
+      });
+    },
+    [won, setBest]
+  );
+
+  const reset = useCallback(() => {
+    setBoard(freshBoard());
+    setScore(0);
+    setOver(false);
+    setWon(false);
+  }, []);
+
+  // Keyboard
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      const map: Record<string, Dir> = {
+        ArrowLeft: "left",
+        ArrowRight: "right",
+        ArrowUp: "up",
+        ArrowDown: "down",
+        a: "left",
+        d: "right",
+        w: "up",
+        s: "down",
+      };
+      const dir = map[e.key];
+      if (!dir) return;
+      e.preventDefault();
+      apply(dir);
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [apply]);
+
+  // Touch swipe
+  const onTouchStart = (e: React.TouchEvent) => {
+    const t = e.touches[0];
+    touchStart.current = { x: t.clientX, y: t.clientY };
+  };
+  const onTouchEnd = (e: React.TouchEvent) => {
+    const start = touchStart.current;
+    if (!start) return;
+    const t = e.changedTouches[0];
+    const dx = t.clientX - start.x;
+    const dy = t.clientY - start.y;
+    touchStart.current = null;
+    if (Math.max(Math.abs(dx), Math.abs(dy)) < SWIPE_THRESHOLD) return;
+    if (Math.abs(dx) > Math.abs(dy)) apply(dx > 0 ? "right" : "left");
+    else apply(dy > 0 ? "down" : "up");
+  };
+
+  return (
+    <div className="container-x flex min-h-screen flex-col items-center pb-20 pt-28">
+      <div className="w-full max-w-md">
+        <Link
+          to="/"
+          className="inline-flex items-center gap-1.5 text-sm text-muted transition-colors hover:text-text"
+        >
+          <ArrowLeft size={16} />
+          홈으로
+        </Link>
+
+        <div className="mt-6 flex items-end justify-between gap-4">
+          <div>
+            <span className="eyebrow">Easter Egg</span>
+            <h1 className="mt-2 text-4xl font-bold">
+              <span className="text-gradient">2048</span>
+            </h1>
+          </div>
+          <div className="flex gap-2">
+            <div className="rounded-xl bg-white/5 px-4 py-2 text-center ring-1 ring-white/10">
+              <p className="text-[0.65rem] uppercase tracking-wider text-muted">Score</p>
+              <p className="text-lg font-bold tabular-nums">{score}</p>
+            </div>
+            <div className="rounded-xl bg-white/5 px-4 py-2 text-center ring-1 ring-white/10">
+              <p className="flex items-center gap-1 text-[0.65rem] uppercase tracking-wider text-muted">
+                <Trophy size={11} className="text-amber-300" /> Best
+              </p>
+              <p className="text-lg font-bold tabular-nums">{best}</p>
+            </div>
+          </div>
+        </div>
+
+        <p className="mt-4 text-sm text-muted">
+          방향키·WASD 또는 <span className="text-text">스와이프</span>로 타일을 밀어 같은 숫자를 합치세요.
+        </p>
+
+        {/* Board */}
+        <div
+          onTouchStart={onTouchStart}
+          onTouchEnd={onTouchEnd}
+          className="relative mt-5 touch-none select-none rounded-2xl bg-white/5 p-3 ring-1 ring-white/10"
+        >
+          <div className="grid grid-cols-4 gap-3">
+            {board.flatMap((row, r) =>
+              row.map((v, c) => (
+                <div
+                  key={`${r}-${c}-${v}`}
+                  className={
+                    "grid aspect-square place-items-center rounded-xl text-2xl font-bold tabular-nums transition-colors duration-150 sm:text-3xl " +
+                    (TILE[v] ?? "bg-gradient-to-br from-accent to-brand text-white") +
+                    (v ? " animate-[pop_0.15s_ease]" : "")
+                  }
+                >
+                  {v || ""}
+                </div>
+              ))
+            )}
+          </div>
+
+          {/* Overlay: win / game over */}
+          {(over || won) && (
+            <div className="absolute inset-0 z-10 grid place-items-center rounded-2xl bg-bg/80 backdrop-blur-sm">
+              <div className="text-center">
+                <p className="text-2xl font-bold">
+                  {won && !over ? "🎉 2048 달성!" : "게임 오버"}
+                </p>
+                <p className="mt-1 text-sm text-muted">점수 {score}</p>
+                <div className="mt-4 flex justify-center gap-2">
+                  {won && !over && (
+                    <button onClick={() => setWon(false)} className="btn btn-ghost">
+                      계속하기
+                    </button>
+                  )}
+                  <button onClick={reset} className="btn btn-primary">
+                    <RotateCcw size={16} />
+                    다시 시작
+                  </button>
+                </div>
+              </div>
+            </div>
+          )}
+        </div>
+
+        <button onClick={reset} className="btn btn-ghost mt-4 w-full">
+          <RotateCcw size={16} />
+          새 게임
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/Game2048.tsx
+++ b/src/pages/Game2048.tsx
@@ -170,7 +170,9 @@ export default function Game2048() {
         w: "up",
         s: "down",
       };
-      const dir = map[e.key];
+      // Fall back to the lowercased key so WASD works under caps lock too
+      // (arrow keys keep their original PascalCase names).
+      const dir = map[e.key] ?? map[e.key.toLowerCase()];
       if (!dir) return;
       e.preventDefault();
       apply(dir);
@@ -269,7 +271,7 @@ export default function Game2048() {
                       계속하기
                     </button>
                   )}
-                  <button onClick={reset} className="btn btn-primary">
+                  <button onClick={reset} autoFocus className="btn btn-primary">
                     <RotateCcw size={16} />
                     다시 시작
                   </button>

--- a/src/pages/Guestbook.tsx
+++ b/src/pages/Guestbook.tsx
@@ -1,0 +1,112 @@
+import { useEffect, useRef } from "react";
+import { ExternalLink, MessageSquareHeart } from "lucide-react";
+import { REPO_OWNER, REPO_NAME } from "../lib/blog";
+
+// giscus configuration. Fill these in after enabling GitHub Discussions on the
+// repo and installing the giscus app — grab the four values from giscus.app.
+// While `repoId`/`categoryId` are placeholders, the page shows setup steps
+// instead of the (broken) widget, so the build is always safe to ship.
+const GISCUS = {
+  repo: `${REPO_OWNER}/${REPO_NAME}` as `${string}/${string}`,
+  repoId: "REPLACE_WITH_REPO_ID",
+  category: "Guestbook",
+  categoryId: "REPLACE_WITH_CATEGORY_ID",
+};
+
+const CONFIGURED =
+  !GISCUS.repoId.startsWith("REPLACE") && !GISCUS.categoryId.startsWith("REPLACE");
+
+function GiscusWidget() {
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    el.innerHTML = "";
+    const script = document.createElement("script");
+    script.src = "https://giscus.app/client.js";
+    script.async = true;
+    script.crossOrigin = "anonymous";
+    const attrs: Record<string, string> = {
+      "data-repo": GISCUS.repo,
+      "data-repo-id": GISCUS.repoId,
+      "data-category": GISCUS.category,
+      "data-category-id": GISCUS.categoryId,
+      "data-mapping": "specific",
+      "data-term": "방명록",
+      "data-strict": "0",
+      "data-reactions-enabled": "1",
+      "data-emit-metadata": "0",
+      "data-input-position": "top",
+      "data-theme": "noborder_dark",
+      "data-lang": "ko",
+      "data-loading": "lazy",
+    };
+    for (const [k, v] of Object.entries(attrs)) script.setAttribute(k, v);
+    el.appendChild(script);
+  }, []);
+
+  return <div ref={ref} className="giscus min-h-[200px]" />;
+}
+
+function SetupNotice() {
+  const steps = [
+    "저장소 Settings → General → Features 에서 Discussions 체크 활성화",
+    "Discussions 에 'Guestbook' 카테고리 생성 (형식: Announcement 권장)",
+    "github.com/apps/giscus 에서 giscus 앱을 이 저장소에 설치",
+    "giscus.app 에 저장소를 입력해 나오는 repo-id 와 category-id 를 복사",
+    "src/pages/Guestbook.tsx 의 GISCUS.repoId / categoryId 에 붙여넣기",
+  ];
+  return (
+    <div className="bento mt-8 p-6">
+      <p className="text-sm font-semibold">방명록을 켜려면 한 번만 설정이 필요해요</p>
+      <p className="mt-1 text-xs text-muted">
+        정적 사이트라 방문자가 자기 GitHub로 직접 글을 남기도록 giscus(=GitHub Discussions)를 씁니다.
+      </p>
+      <ol className="mt-4 space-y-2.5">
+        {steps.map((s, i) => (
+          <li key={i} className="flex gap-3 text-sm">
+            <span className="grid h-6 w-6 shrink-0 place-items-center rounded-full bg-brand/15 text-xs font-semibold text-brand">
+              {i + 1}
+            </span>
+            <span className="leading-relaxed text-muted">{s}</span>
+          </li>
+        ))}
+      </ol>
+      <a
+        href="https://giscus.app"
+        target="_blank"
+        rel="noopener noreferrer"
+        className="btn btn-ghost mt-5 text-sm"
+      >
+        <ExternalLink size={15} />
+        giscus.app 열기
+      </a>
+    </div>
+  );
+}
+
+export default function Guestbook() {
+  return (
+    <div className="container-x pb-20 pt-28">
+      <header className="max-w-2xl">
+        <span className="eyebrow">Guestbook</span>
+        <h1 className="mt-3 flex items-center gap-3 text-4xl font-bold sm:text-5xl">
+          <MessageSquareHeart className="text-brand" size={36} />
+          방명록
+        </h1>
+        <p className="mt-4 text-pretty text-muted">
+          다녀가신 흔적을 남겨주세요. GitHub 계정으로 로그인하면 바로 글과 이모지를 남길 수 있어요.
+        </p>
+      </header>
+
+      {CONFIGURED ? (
+        <div className="mt-10">
+          <GiscusWidget />
+        </div>
+      ) : (
+        <SetupNotice />
+      )}
+    </div>
+  );
+}

--- a/src/pages/Portfolio.tsx
+++ b/src/pages/Portfolio.tsx
@@ -2,9 +2,11 @@ import { useEffect } from "react";
 import { useLocation } from "react-router-dom";
 import Hero from "../sections/Hero";
 import About from "../sections/About";
+import Timeline from "../sections/Timeline";
 import Skills from "../sections/Skills";
 import Projects from "../sections/Projects";
 import Contact from "../sections/Contact";
+import SectionDots from "../components/SectionDots";
 
 type ScrollState = { scrollTo?: string };
 
@@ -23,8 +25,10 @@ export default function Portfolio() {
 
   return (
     <>
+      <SectionDots />
       <Hero />
       <div id="about"><About /></div>
+      <div id="journey"><Timeline /></div>
       <div id="skills"><Skills /></div>
       <div id="projects"><Projects /></div>
       <div id="contact"><Contact /></div>

--- a/src/sections/About.tsx
+++ b/src/sections/About.tsx
@@ -9,6 +9,7 @@ import {
   Briefcase,
   LayoutGrid,
   Library,
+  Gamepad2,
 } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 import profileImage from "../assets/images/profileImage.jpg";
@@ -101,6 +102,10 @@ export default function About() {
                       <Link to="/archive" className="btn btn-ghost w-full justify-start">
                         <Library size={16} className="text-brand" />
                         Archive
+                      </Link>
+                      <Link to="/2048" className="btn btn-ghost w-full justify-start">
+                        <Gamepad2 size={16} className="text-accent" />
+                        2048
                       </Link>
                     </div>
                   </motion.div>

--- a/src/sections/Contact.tsx
+++ b/src/sections/Contact.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { Check, Copy, Github, Mail, Code2, ArrowUpRight } from "lucide-react";
 import SectionHeader from "../components/SectionHeader";
 import Reveal from "../components/Reveal";
+import GithubActivity from "../components/GithubActivity";
 
 const EMAIL = "wjdgnsxhsl@naver.com";
 
@@ -88,6 +89,10 @@ export default function Contact() {
               </div>
               <ArrowUpRight size={18} className="text-muted transition-transform group-hover:translate-x-0.5 group-hover:-translate-y-0.5" />
             </a>
+          </Reveal>
+
+          <Reveal className="sm:col-span-2" delay={0.15}>
+            <GithubActivity />
           </Reveal>
         </div>
       </div>

--- a/src/sections/Hero.tsx
+++ b/src/sections/Hero.tsx
@@ -19,7 +19,7 @@ const MARQUEE = [
 
 export default function Hero() {
   return (
-    <section className="relative flex min-h-[100svh] items-center overflow-hidden">
+    <section id="hero" className="relative flex min-h-[100svh] items-center overflow-hidden">
       {/* ambient orbs */}
       <div className="pointer-events-none absolute -left-24 top-20 h-72 w-72 rounded-full bg-brand/25 blur-[100px]" />
       <div className="pointer-events-none absolute right-0 top-1/3 h-80 w-80 rounded-full bg-brand-3/20 blur-[120px]" />

--- a/src/sections/Timeline.tsx
+++ b/src/sections/Timeline.tsx
@@ -1,0 +1,75 @@
+import { Briefcase, GraduationCap, Trophy, FolderGit2 } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+import SectionHeader from "../components/SectionHeader";
+import Reveal from "../components/Reveal";
+import { timeline, type TimelineKind } from "../data/timeline";
+
+const KIND_META: Record<TimelineKind, { icon: LucideIcon; tint: string }> = {
+  work: { icon: Briefcase, tint: "text-brand" },
+  education: { icon: GraduationCap, tint: "text-brand-3" },
+  award: { icon: Trophy, tint: "text-amber-300" },
+  project: { icon: FolderGit2, tint: "text-accent" },
+};
+
+export default function Timeline() {
+  return (
+    <section className="section">
+      <div className="container-x">
+        <SectionHeader
+          eyebrow="Journey"
+          title={
+            <>
+              걸어온 <span className="text-gradient">길</span>
+            </>
+          }
+          description="교육부터 프로젝트, 그리고 현재까지 — 개발자로 성장해 온 발자취입니다."
+        />
+
+        <div className="mt-12 max-w-3xl">
+          <ol className="relative border-l border-white/10 pl-6 sm:pl-8">
+            {timeline.map((entry, i) => {
+              const meta = KIND_META[entry.kind];
+              const Icon = meta.icon;
+              return (
+                <li key={`${entry.title}-${i}`} className="relative pb-10 last:pb-0">
+                  {/* node on the rail */}
+                  <span className="absolute -left-[2.1rem] top-0 grid h-9 w-9 place-items-center rounded-full bg-surface ring-1 ring-white/10 sm:-left-[2.85rem]">
+                    <Icon size={16} className={meta.tint} />
+                  </span>
+
+                  <Reveal y={16} delay={0.04 * i}>
+                    <article className="bento p-5">
+                      <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
+                        <span className="text-xs font-semibold uppercase tracking-wider text-brand">
+                          {entry.period}
+                        </span>
+                        {entry.org && (
+                          <span className="text-xs text-muted">· {entry.org}</span>
+                        )}
+                      </div>
+                      <h3 className="mt-1.5 text-lg font-semibold">{entry.title}</h3>
+                      {entry.description && (
+                        <p className="mt-2 text-sm leading-relaxed text-muted">
+                          {entry.description}
+                        </p>
+                      )}
+                      {entry.tags && entry.tags.length > 0 && (
+                        <div className="mt-3 flex flex-wrap gap-2">
+                          {entry.tags.map((t) => (
+                            <span key={t} className="chip">
+                              {t}
+                            </span>
+                          ))}
+                        </div>
+                      )}
+                    </article>
+                  </Reveal>
+                </li>
+              );
+            })}
+          </ol>
+        </div>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## 추가 기능 6종

### 1. 스크롤 진행바 (`ScrollProgress`)
상단에 스크롤 위치를 따라 차오르는 그라데이션 바. 전역 적용, 장식용이라 탭 순서에서 제외.

### 2. 섹션 도트 내비 (`SectionDots`)
우측 세로 점 내비게이션(데스크톱). `IntersectionObserver`로 현재 섹션 추적, 클릭 시 점프. Hero에 `id="hero"` 추가.

### 3. 경력·교육 타임라인 (`Journey` 섹션)
`src/data/timeline.ts` 기반 세로 타임라인(재직/교육/수상/프로젝트). About↔Skills 사이 배치.
> ⚠️ 날짜·문구는 알고 있는 정보로 시드만 해뒀어요. `timeline.ts`에서 자유롭게 다듬으면 됩니다.

### 4. GitHub 활동 위젯 (`GithubActivity`)
토큰 없는 공개 API로 지난 1년 잔디를 받아 **디자인 토큰으로 직접 렌더**(이미지 핫링크 X). Contact 그리드에 배치.

### 5. 방명록 `/guestbook` — giscus
GitHub Discussions 기반이라 방문자가 자기 GitHub로 바로 작성. `Guestbook.tsx`의 `repoId`/`categoryId`가 placeholder인 동안은 **설정 안내 단계가 표시**되어 빌드는 항상 안전. Footer에 진입 링크 추가.
> 켜려면: 저장소 Discussions 활성화 → 'Guestbook' 카테고리 생성 → giscus 앱 설치 → giscus.app에서 받은 두 ID 붙여넣기.

### 6. 숨겨진 2048 `/2048`
키보드·WASD·**모바일 스와이프** 지원, 최고점 localStorage 저장. 메인 내비엔 없고 **About 프로필 5탭 시크릿 내비**로 진입. 타일 등장/병합용 `pop` 키프레임 추가.

## 검증
- `npm run typecheck` ✅ · `npm run build` ✅
- `vite preview`: `/`, `/guestbook`, `/2048` 모두 SPA로 정상 서빙 확인

## 확정 스코프 메모
스크롤 진행바·도트 내비·GitHub 위젯·타임라인 + 재미 기능(방명록 giscus·2048 모바일 대응)으로 합의된 6종 전부 포함.

https://claude.ai/code/session_0131VNZxJHuHREuhS6SqTEoo

---
_Generated by [Claude Code](https://claude.ai/code/session_0131VNZxJHuHREuhS6SqTEoo)_