### PR TITLE
fix: 모바일 GitHub 잔디 가로 넘침 수정 + 푸터에 마지막 업데이트 날짜

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -6,9 +6,12 @@ export default function Footer() {
   return (
     <footer className="border-t border-white/5 py-10">
       <div className="container-x flex flex-col items-center justify-between gap-4 sm:flex-row">
-        <p className="text-sm text-muted">
-          © {year} Jeong Hoon. Built with React · Vite · Tailwind.
-        </p>
+        <div className="text-center sm:text-left">
+          <p className="text-sm text-muted">
+            © {year} Jeong Hoon. Built with React · Vite · Tailwind.
+          </p>
+          <p className="mt-1 text-xs text-muted/70">마지막 업데이트 · {__BUILD_DATE__}</p>
+        </div>
         <div className="flex items-center gap-4 text-muted">
           <Link
             to="/guestbook"

--- a/src/components/GithubActivity.tsx
+++ b/src/components/GithubActivity.tsx
@@ -73,10 +73,10 @@ export default function GithubActivity() {
       href={`https://github.com/${REPO_OWNER}`}
       target="_blank"
       rel="noopener noreferrer"
-      className="bento group block p-6"
+      className="bento group block min-w-0 p-6"
     >
-      <div className="flex items-center justify-between">
-        <div className="flex items-center gap-3">
+      <div className="flex items-center justify-between gap-2">
+        <div className="flex min-w-0 items-center gap-3">
           <span className="grid h-10 w-10 place-items-center rounded-xl bg-white/5 ring-1 ring-white/10">
             <Github size={20} className="text-brand" />
           </span>

--- a/src/sections/Contact.tsx
+++ b/src/sections/Contact.tsx
@@ -91,7 +91,7 @@ export default function Contact() {
             </a>
           </Reveal>
 
-          <Reveal className="sm:col-span-2" delay={0.15}>
+          <Reveal className="min-w-0 sm:col-span-2" delay={0.15}>
             <GithubActivity />
           </Reveal>
         </div>

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,4 @@
 /// <reference types="vite/client" />
+
+// Injected by Vite `define` (see vite.config.ts) — site build/last-update date.
+declare const __BUILD_DATE__: string;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,6 +8,11 @@ import path from "node:path";
 export default defineConfig({
   base: "/",
   plugins: [react(), tailwindcss()],
+  // Build timestamp (YYYY-MM-DD) injected at build time. Deploys run on every
+  // push to main, so this reflects the site's last-updated date in the footer.
+  define: {
+    __BUILD_DATE__: JSON.stringify(new Date().toISOString().slice(0, 10)),
+  },
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "src"),


### PR DESCRIPTION
## 1. 모바일 GitHub 잔디 가로 넘침 수정
잔디(약 52주 ≈ 728px)가 들어있는 **그리드 아이템의 기본 `min-width:auto`** 때문에 칸이 콘텐츠 너비만큼 늘어나 모바일에서 뷰포트를 넘겼습니다. 그리드 아이템(Contact의 Reveal)과 카드에 **`min-w-0`** 를 줘서, `overflow-x-auto` 래퍼가 칸을 늘리는 대신 실제로 **가로 스크롤**되도록 수정.

## 2. 푸터에 마지막 업데이트 날짜
- `vite.config.ts`에 빌드 시각을 `__BUILD_DATE__`(YYYY-MM-DD)로 주입(`define`).
- `main` 푸시마다 배포가 도니 이 값이 곧 **사이트 최종 업데이트 날짜**.
- 푸터에 `마지막 업데이트 · YYYY-MM-DD` 표시. 타입 선언은 `vite-env.d.ts`에 추가.

## 검증
- `npm run typecheck` ✅ · `npm run build` ✅ (날짜 주입·문구 번들 포함 확인)

https://claude.ai/code/session_0131VNZxJHuHREuhS6SqTEoo

---
_Generated by [Claude Code](https://claude.ai/code/session_0131VNZxJHuHREuhS6SqTEoo)_