### PR TITLE
feat(archive): 문서 수정 기능 추가 (파일 교체 포함)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import BlogPost from "./pages/BlogPost";
 import BlogWrite from "./pages/BlogWrite";
 import Archive from "./pages/Archive";
 import ArchiveUpload from "./pages/ArchiveUpload";
+import ArchiveEdit from "./pages/ArchiveEdit";
 import Guestbook from "./pages/Guestbook";
 import Game2048 from "./pages/Game2048";
 
@@ -36,6 +37,7 @@ export default function App() {
           <Route path="/blog/:number" element={<BlogPost />} />
           <Route path="/archive" element={<Archive />} />
           <Route path="/archive/upload" element={<ArchiveUpload />} />
+          <Route path="/archive/edit/:category/:slug" element={<ArchiveEdit />} />
           <Route path="/guestbook" element={<Guestbook />} />
           <Route path="/2048" element={<Game2048 />} />
           <Route path="*" element={<Portfolio />} />

--- a/src/lib/archive.ts
+++ b/src/lib/archive.ts
@@ -219,6 +219,66 @@ export async function publishDoc(input: PublishInput): Promise<ArchiveDoc> {
   return entry;
 }
 
+/* ------------------------------ updating -------------------------------- */
+
+export type UpdateInput = {
+  original: ArchiveDoc; // the document being edited (its current path/date)
+  slug: string;
+  title: string;
+  category: string;
+  description: string;
+  html: string; // full HTML to commit — either the unchanged original or a replacement
+};
+
+// Owner-only. Re-commits the document's HTML (replaced or kept) and updates its
+// manifest entry in a single commit. If the slug/category changed the file is
+// moved: the new path is written and the old file removed (unless another entry
+// still points at it). The original publish date is preserved.
+export async function updateDoc(input: UpdateInput): Promise<ArchiveDoc> {
+  const token = getToken();
+  if (!token) throw new Error("수정하려면 GitHub 토큰이 필요합니다.");
+
+  const newPath = `docs/${input.category}/${input.slug}.html`;
+  const entry: ArchiveDoc = {
+    slug: input.slug,
+    title: input.title.trim(),
+    category: input.category,
+    description: input.description.trim(),
+    path: newPath,
+    date: input.original.date,
+  };
+
+  // Replace the original entry in place (preserving list order); drop any other
+  // entry that collides with the new path so the edit wins.
+  const existing = await readSourceDocs(token, DEPLOY_BRANCH);
+  const next: ArchiveDoc[] = [];
+  let replaced = false;
+  for (const d of existing) {
+    if (d.path === input.original.path) {
+      next.push(entry);
+      replaced = true;
+    } else if (d.path === newPath) {
+      continue;
+    } else {
+      next.push(d);
+    }
+  }
+  if (!replaced) next.unshift(entry);
+  const manifest = JSON.stringify({ docs: next }, null, 2) + "\n";
+
+  const files: CommitFile[] = [
+    { path: `public/${newPath}`, content: input.html },
+    { path: `public/docs/index.json`, content: manifest },
+  ];
+  // Path changed → remove the old file, unless something still references it.
+  if (input.original.path !== newPath && !next.some((d) => d.path === input.original.path)) {
+    files.push({ path: `public/${input.original.path}`, content: null });
+  }
+
+  await commitFiles(token, files, `docs: update ${entry.title}`, DEPLOY_BRANCH);
+  return entry;
+}
+
 /* ------------------------------ deleting -------------------------------- */
 
 // Owner-only. Removes a document's HTML file and drops it from the manifest in

--- a/src/pages/Archive.tsx
+++ b/src/pages/Archive.tsx
@@ -7,6 +7,7 @@ import {
   Code2,
   FileText,
   Loader2,
+  Pencil,
   Plane,
   Trash2,
   Upload,
@@ -218,20 +219,30 @@ export default function Archive() {
                       </a>
 
                       {canUpload && (
-                        <button
-                          type="button"
-                          onClick={() => handleDelete(doc)}
-                          disabled={deletingPath === doc.path}
-                          aria-label="문서 삭제"
-                          title="문서 삭제"
-                          className="absolute bottom-3 right-3 grid h-8 w-8 place-items-center rounded-lg border border-white/10 bg-white/5 text-muted opacity-0 transition-all hover:border-red-500/40 hover:bg-red-500/10 hover:text-red-300 focus-visible:opacity-100 group-hover:opacity-100 disabled:opacity-100 [@media(hover:none)]:opacity-100"
-                        >
-                          {deletingPath === doc.path ? (
-                            <Loader2 size={15} className="animate-spin" />
-                          ) : (
-                            <Trash2 size={15} />
-                          )}
-                        </button>
+                        <div className="absolute bottom-3 right-3 flex items-center gap-1.5 opacity-0 transition-all focus-within:opacity-100 group-hover:opacity-100 [@media(hover:none)]:opacity-100">
+                          <Link
+                            to={`/archive/edit/${doc.category}/${doc.slug}`}
+                            aria-label="문서 수정"
+                            title="문서 수정"
+                            className="grid h-8 w-8 place-items-center rounded-lg border border-white/10 bg-white/5 text-muted transition-all hover:border-brand/40 hover:bg-brand/10 hover:text-brand"
+                          >
+                            <Pencil size={15} />
+                          </Link>
+                          <button
+                            type="button"
+                            onClick={() => handleDelete(doc)}
+                            disabled={deletingPath === doc.path}
+                            aria-label="문서 삭제"
+                            title="문서 삭제"
+                            className="grid h-8 w-8 place-items-center rounded-lg border border-white/10 bg-white/5 text-muted transition-all hover:border-red-500/40 hover:bg-red-500/10 hover:text-red-300 disabled:opacity-100"
+                          >
+                            {deletingPath === doc.path ? (
+                              <Loader2 size={15} className="animate-spin" />
+                            ) : (
+                              <Trash2 size={15} />
+                            )}
+                          </button>
+                        </div>
                       )}
                     </motion.div>
                   ))}

--- a/src/pages/ArchiveEdit.tsx
+++ b/src/pages/ArchiveEdit.tsx
@@ -1,0 +1,399 @@
+import { useEffect, useMemo, useState } from "react";
+import { Link, useNavigate, useParams } from "react-router-dom";
+import {
+  AlertCircle,
+  ArrowLeft,
+  CheckCircle2,
+  ExternalLink,
+  Eye,
+  EyeOff,
+  FileUp,
+  KeyRound,
+  Loader2,
+  RotateCcw,
+  Save,
+  ShieldAlert,
+} from "lucide-react";
+import {
+  CATEGORIES,
+  docUrl,
+  fetchDocs,
+  getToken,
+  setToken,
+  verifyToken,
+  isAllowedAuthor,
+  updateDoc,
+  slugify,
+  htmlTitle,
+  REPO_OWNER,
+  REPO_NAME,
+  type ArchiveDoc,
+} from "../lib/archive";
+
+type Account =
+  | { state: "idle" }
+  | { state: "checking" }
+  | { state: "done"; login: string | null; allowed: boolean };
+
+const TOKEN_URL =
+  "https://github.com/settings/tokens/new?scopes=public_repo&description=archive-" + REPO_NAME;
+
+export default function ArchiveEdit() {
+  const navigate = useNavigate();
+  const { category: routeCategory, slug: routeSlug } = useParams();
+
+  const [token, setTokenState] = useState(getToken());
+  const [showToken, setShowToken] = useState(false);
+  const [account, setAccount] = useState<Account>({ state: "idle" });
+
+  // The document being edited, resolved from the manifest by its path.
+  const [original, setOriginal] = useState<ArchiveDoc | null>(null);
+  const [loadState, setLoadState] = useState<"loading" | "ready" | "error">("loading");
+  const [loadError, setLoadError] = useState("");
+
+  const [html, setHtml] = useState("");
+  const [fileReplaced, setFileReplaced] = useState(false);
+  const [fileName, setFileName] = useState("");
+  const [title, setTitle] = useState("");
+  const [category, setCategory] = useState(CATEGORIES[0].id);
+  const [slug, setSlug] = useState("");
+  const [description, setDescription] = useState("");
+
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState("");
+
+  // Verify the token's account (debounced) — only the owner can save.
+  useEffect(() => {
+    const t = token.trim();
+    if (!t) {
+      setAccount({ state: "idle" });
+      return;
+    }
+    setAccount({ state: "checking" });
+    const handle = setTimeout(async () => {
+      const login = await verifyToken(t);
+      setAccount({ state: "done", login, allowed: !!login && isAllowedAuthor(login) });
+    }, 600);
+    return () => clearTimeout(handle);
+  }, [token]);
+
+  // Resolve the target document from the manifest and pre-fill the form, then
+  // fetch its current HTML so the preview works and the unchanged file can be
+  // re-committed verbatim if the owner doesn't replace it.
+  useEffect(() => {
+    let alive = true;
+    const targetPath = `docs/${routeCategory}/${routeSlug}.html`;
+    setLoadState("loading");
+    fetchDocs()
+      .then(async (docs) => {
+        if (!alive) return;
+        const doc = docs.find((d) => d.path === targetPath);
+        if (!doc) {
+          setLoadError("해당 문서를 찾을 수 없습니다.");
+          setLoadState("error");
+          return;
+        }
+        setOriginal(doc);
+        setTitle(doc.title);
+        setCategory(doc.category);
+        setSlug(doc.slug);
+        setDescription(doc.description);
+        try {
+          const res = await fetch(docUrl(doc.path), { cache: "no-store" });
+          const text = res.ok ? await res.text() : "";
+          if (alive) setHtml(text);
+        } catch {
+          /* preview/keep-content is best-effort; saving without a replacement
+             would otherwise wipe the file, so guard that in canSave below. */
+        }
+        if (alive) setLoadState("ready");
+      })
+      .catch((e: unknown) => {
+        if (!alive) return;
+        setLoadError(e instanceof Error ? e.message : String(e));
+        setLoadState("error");
+      });
+    return () => {
+      alive = false;
+    };
+  }, [routeCategory, routeSlug]);
+
+  const isOwner = account.state === "done" && account.allowed;
+  const effectiveSlug = slug.trim() || slugify(title || fileName);
+  const canSave =
+    isOwner && !!html.trim() && !!title.trim() && !!effectiveSlug && !saving && loadState === "ready";
+
+  const saveToken = (value: string) => {
+    setTokenState(value);
+    setToken(value.trim());
+  };
+
+  const onFile = async (file: File | undefined) => {
+    if (!file) return;
+    const text = await file.text();
+    setHtml(text);
+    setFileName(file.name);
+    setFileReplaced(true);
+    const t = htmlTitle(text);
+    if (t) setTitle(t);
+  };
+
+  const previewSrc = useMemo(() => html, [html]);
+
+  const save = async () => {
+    setError("");
+    if (!original) return;
+    if (!isOwner) return setError("사이트 소유자만 수정할 수 있습니다.");
+    if (!html.trim()) return setError("문서 내용을 불러오지 못했습니다. 파일을 교체해 주세요.");
+    if (!title.trim()) return setError("제목을 입력해 주세요.");
+
+    setSaving(true);
+    try {
+      const doc = await updateDoc({
+        original,
+        slug: effectiveSlug,
+        title,
+        category,
+        description,
+        html,
+      });
+      navigate("/archive", { state: { updated: doc.path } });
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : String(e));
+      setSaving(false);
+    }
+  };
+
+  const field =
+    "w-full rounded-xl border border-white/10 bg-white/5 px-4 py-2.5 text-sm text-text outline-none transition-colors focus:border-brand/60";
+
+  return (
+    <div className="container-x pb-20 pt-28">
+      <Link
+        to="/archive"
+        className="inline-flex items-center gap-1.5 text-sm text-muted transition-colors hover:text-text"
+      >
+        <ArrowLeft size={16} />
+        아카이브
+      </Link>
+
+      <header className="mt-6 max-w-2xl">
+        <span className="eyebrow">Edit</span>
+        <h1 className="mt-3 text-3xl font-bold sm:text-4xl">문서 수정</h1>
+        <p className="mt-4 text-pretty text-sm text-muted">
+          제목·카테고리·설명·파일명을 고치거나 HTML 파일을 교체할 수 있습니다. 파일을 교체하지
+          않으면 기존 내용이 그대로 유지됩니다. 저장하면 저장소에 커밋되고 GitHub Actions가 자동
+          배포해 1~2분 뒤 반영됩니다.
+        </p>
+      </header>
+
+      {loadState === "loading" && (
+        <div className="mt-16 flex items-center justify-center gap-2 text-muted">
+          <Loader2 size={18} className="animate-spin" />
+          문서를 불러오는 중…
+        </div>
+      )}
+
+      {loadState === "error" && (
+        <div className="mt-16 flex flex-col items-center gap-3 text-center">
+          <AlertCircle size={28} className="text-red-400" />
+          <p className="text-muted">{loadError}</p>
+          <Link to="/archive" className="btn btn-ghost mt-2">
+            아카이브로 돌아가기
+          </Link>
+        </div>
+      )}
+
+      {loadState === "ready" && (
+        <>
+          {/* token */}
+          <details className="bento mt-8 p-5" open={!token}>
+            <summary className="flex cursor-pointer items-center gap-2 text-sm font-semibold">
+              <KeyRound size={16} className="text-brand" />
+              GitHub 토큰 {token ? "· 저장됨" : "· 필요"}
+            </summary>
+            <div className="mt-4 space-y-3">
+              <p className="text-xs leading-relaxed text-muted">
+                정적 사이트라 수정하려면 본인 GitHub 토큰이 필요합니다. 토큰은 이 브라우저
+                (localStorage)에만 저장되며, 저장 시 GitHub API 직접 호출에만 쓰입니다. 블로그
+                글쓰기와 같은 토큰을 공유합니다. 공용 PC에서는 사용하지 마세요.
+              </p>
+              <a
+                href={TOKEN_URL}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-1.5 text-xs text-brand hover:text-accent"
+              >
+                <ExternalLink size={13} />
+                토큰 발급 (classic · <code className="mx-1">public_repo</code> 권한)
+              </a>
+              <div className="flex items-center gap-2">
+                <input
+                  type={showToken ? "text" : "password"}
+                  className={field}
+                  value={token}
+                  onChange={(e) => saveToken(e.target.value)}
+                  placeholder="ghp_..."
+                  autoComplete="off"
+                  spellCheck={false}
+                />
+                <button
+                  type="button"
+                  onClick={() => setShowToken((v) => !v)}
+                  className="btn btn-ghost p-2.5"
+                  aria-label={showToken ? "토큰 숨기기" : "토큰 표시"}
+                >
+                  {showToken ? <EyeOff size={16} /> : <Eye size={16} />}
+                </button>
+              </div>
+              <p className="text-xs text-muted">
+                대상: <code>{REPO_OWNER}/{REPO_NAME}</code> · 소유자(<code>@{REPO_OWNER}</code>)만 가능
+              </p>
+              {account.state === "checking" && (
+                <p className="flex items-center gap-1.5 text-xs text-muted">
+                  <Loader2 size={13} className="animate-spin" />
+                  토큰 확인 중…
+                </p>
+              )}
+              {account.state === "done" && account.allowed && (
+                <p className="flex items-center gap-1.5 text-xs text-emerald-400">
+                  <CheckCircle2 size={13} />@{account.login} 으로 인증됨 · 수정 가능
+                </p>
+              )}
+              {account.state === "done" && !account.allowed && (
+                <p className="flex items-center gap-1.5 text-xs text-amber-400">
+                  <ShieldAlert size={13} />
+                  {account.login
+                    ? `@${account.login} 계정은 수정 권한이 없습니다 (소유자 전용).`
+                    : "토큰이 유효하지 않습니다."}
+                </p>
+              )}
+            </div>
+          </details>
+
+          <div className="mt-8 grid gap-8 lg:grid-cols-2">
+            {/* form */}
+            <div className="space-y-4">
+              <div>
+                <label className="mb-1.5 block text-xs font-semibold text-muted">
+                  HTML 파일 교체 (선택)
+                </label>
+                <label className="flex cursor-pointer items-center gap-3 rounded-xl border border-dashed border-white/15 bg-white/5 px-4 py-4 text-sm text-muted transition-colors hover:border-brand/50">
+                  <FileUp size={18} className="text-brand" />
+                  <span className="min-w-0 truncate">
+                    {fileReplaced
+                      ? fileName
+                      : "여기를 눌러 새 .html 파일 선택 (선택 안 하면 기존 내용 유지)"}
+                  </span>
+                  <input
+                    type="file"
+                    accept=".html,text/html"
+                    className="hidden"
+                    onChange={(e) => onFile(e.target.files?.[0])}
+                  />
+                </label>
+                {fileReplaced && (
+                  <p className="mt-1.5 flex items-center gap-1.5 text-xs text-amber-400">
+                    <RotateCcw size={12} />새 파일로 교체됩니다.
+                  </p>
+                )}
+              </div>
+
+              <div>
+                <label className="mb-1.5 block text-xs font-semibold text-muted">제목</label>
+                <input
+                  className={field}
+                  value={title}
+                  onChange={(e) => setTitle(e.target.value)}
+                  placeholder="문서 제목"
+                />
+              </div>
+
+              <div className="grid grid-cols-2 gap-4">
+                <div>
+                  <label className="mb-1.5 block text-xs font-semibold text-muted">카테고리</label>
+                  <select
+                    className={field}
+                    value={category}
+                    onChange={(e) => setCategory(e.target.value)}
+                  >
+                    {CATEGORIES.map((c) => (
+                      <option key={c.id} value={c.id} className="bg-surface">
+                        {c.label}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+                <div>
+                  <label className="mb-1.5 block text-xs font-semibold text-muted">
+                    파일명 (slug)
+                  </label>
+                  <input
+                    className={field}
+                    value={slug}
+                    onChange={(e) => setSlug(e.target.value)}
+                    placeholder={slugify(title || fileName || "")}
+                  />
+                </div>
+              </div>
+
+              <div>
+                <label className="mb-1.5 block text-xs font-semibold text-muted">설명</label>
+                <input
+                  className={field}
+                  value={description}
+                  onChange={(e) => setDescription(e.target.value)}
+                  placeholder="목록 카드에 보일 한 줄 설명"
+                />
+              </div>
+
+              {error && (
+                <div className="flex items-start gap-2 rounded-xl border border-red-500/30 bg-red-500/10 p-3 text-sm text-red-300">
+                  <AlertCircle size={16} className="mt-0.5 shrink-0" />
+                  <span>{error}</span>
+                </div>
+              )}
+
+              <button
+                onClick={save}
+                disabled={!canSave}
+                className="btn btn-primary w-full disabled:opacity-50"
+              >
+                {saving ? <Loader2 size={16} className="animate-spin" /> : <Save size={16} />}
+                {saving ? "저장 중…" : "저장하기"}
+              </button>
+              <p className="text-xs text-muted">
+                저장 위치: <code>docs/{category}/{effectiveSlug || "..."}.html</code>
+                {original && `docs/${category}/${effectiveSlug}.html` !== original.path && (
+                  <>
+                    {" "}
+                    · 기존 <code>{original.path}</code> 에서 이동
+                  </>
+                )}
+              </p>
+            </div>
+
+            {/* preview */}
+            <div className="bento overflow-hidden p-0">
+              <p className="border-b border-white/10 px-5 py-3 text-xs font-semibold uppercase tracking-widest text-muted">
+                미리보기
+              </p>
+              {previewSrc ? (
+                <iframe
+                  title="문서 미리보기"
+                  srcDoc={previewSrc}
+                  sandbox="allow-scripts allow-popups"
+                  className="h-[600px] w-full bg-white"
+                />
+              ) : (
+                <p className="p-6 text-sm text-muted">
+                  내용을 불러오지 못했습니다. 파일을 교체하면 여기에서 미리 볼 수 있습니다.
+                </p>
+              )}
+            </div>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## 개요

아카이브에 기존 업로드·삭제에 더해 **문서 수정 기능**을 추가했습니다. 메타데이터(제목·카테고리·설명·파일명) 편집과 **HTML 파일 교체**를 모두 지원합니다.

## 변경 사항

- **`src/lib/archive.ts`** — `updateDoc()` 추가
  - HTML(교체본 또는 기존 내용)과 매니페스트 엔트리를 한 커밋으로 갱신.
  - slug/카테고리 변경 시 새 경로로 파일 이동 → 옛 파일은 다른 엔트리가 참조하지 않을 때만 제거.
  - 매니페스트 내 순서는 그대로 유지(원위치 교체), 원본 게시일(`date`) 보존.
- **`src/pages/ArchiveEdit.tsx`** (신규) — `/archive/edit/:category/:slug` 페이지
  - 매니페스트에서 대상 문서를 찾아 폼에 기존 값 미리 채움.
  - 현재 HTML을 불러와 미리보기에 표시하고, 파일을 교체하지 않으면 기존 내용을 그대로 재커밋.
  - 업로드 페이지와 동일한 소유자 토큰 검증 흐름 재사용.
- **`src/App.tsx`** — `/archive/edit/:category/:slug` 라우트 등록.
- **`src/pages/Archive.tsx`** — 카드에 수정 버튼 추가(소유자 전용, 삭제 버튼과 그룹화).

## 검증

- `npm run typecheck` 통과
- `npm run build` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gi4Dy6rBsQH3MHCvChDQmx)_