### PR TITLE
fix(archive): 소유자용 수정·삭제 버튼 항상 노출

### DIFF
--- a/src/pages/Archive.tsx
+++ b/src/pages/Archive.tsx
@@ -219,7 +219,7 @@ export default function Archive() {
                       </a>
 
                       {canUpload && (
-                        <div className="absolute bottom-3 right-3 flex items-center gap-1.5 opacity-0 transition-all focus-within:opacity-100 group-hover:opacity-100 [@media(hover:none)]:opacity-100">
+                        <div className="absolute bottom-3 right-3 flex items-center gap-1.5">
                           <Link
                             to={`/archive/edit/${doc.category}/${doc.slug}`}
                             aria-label="문서 수정"


### PR DESCRIPTION
## 개요

아카이브 카드의 수정·삭제 버튼이 데스크톱에서 카드에 마우스를 올렸을 때만(hover) 보여 "수정 버튼이 안 보인다"는 문제가 있었습니다. 소유자에게는 항상 보이도록 변경합니다.

## 변경 사항

- **`src/pages/Archive.tsx`** — 카드 컨트롤 컨테이너에서 `opacity-0` + `group-hover/focus-within` 노출 게이팅을 제거. 소유자(`canUpload`)에게 수정·삭제 버튼이 상시 표시됩니다.

## 검증

- `npm run typecheck` 통과
- `npm run build` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gi4Dy6rBsQH3MHCvChDQmx)_